### PR TITLE
Refactor package names as well as the way mappings for javascript and lua work

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If the Mapping field contains a script, it is executed in the context of the fol
 # Maven
 
     <dependency>
-        <groupId>com.github.ansell.csvsum</groupId>
+        <groupId>com.github.ansell.csv.sum</groupId>
         <artifactId>csvsum</artifactId>
         <version>0.0.3</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.ansell.csvsum</groupId>
+	<groupId>com.github.ansell.csv.sum</groupId>
 	<artifactId>csvsum</artifactId>
 	<version>0.0.4-SNAPSHOT</version>
 	<name>CSVSum</name>
@@ -158,11 +158,11 @@
 				<configuration>
 					<programs>
 						<program>
-							<mainClass>com.github.ansell.csvsum.CSVSummariser</mainClass>
+							<mainClass>com.github.ansell.csv.sum.CSVSummariser</mainClass>
 							<id>csvsum</id>
 						</program>
 						<program>
-							<mainClass>com.github.ansell.csvmap.CSVMapper</mainClass>
+							<mainClass>com.github.ansell.csv.map.CSVMapper</mainClass>
 							<id>csvmap</id>
 						</program>
 					</programs>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
 			<artifactId>jool</artifactId>
 			<version>0.9.10</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.jsonld-java</groupId>
+			<artifactId>jsonld-java</artifactId>
+			<version>0.8.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/com/github/ansell/csv/map/CSVMapper.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapper.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvmap;
+package com.github.ansell.csv.map;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -46,7 +46,7 @@ import org.jooq.lambda.Unchecked;
 
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.github.ansell.csvutil.CSVUtil;
+import com.github.ansell.csv.util.CSVUtil;
 
 import joptsimple.OptionException;
 import joptsimple.OptionParser;

--- a/src/main/java/com/github/ansell/csv/map/CSVMapping.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapping.java
@@ -114,7 +114,7 @@ class CSVMapping {
 
 	private void init() {
 		// Short circuit if the mapping is the default mapping and avoid
-		// creating an instance of nashorn for this mapping
+		// creating an instance of nashorn/groovy/etc. for this mapping
 		if (this.mapping.equalsIgnoreCase(DEFAULT_MAPPING) || this.language == CSVMappingLanguage.DEFAULT) {
 			return;
 		}
@@ -125,8 +125,8 @@ class CSVMapping {
 				scriptEngine = SCRIPT_MANAGER.getEngineByName("javascript");
 
 				scriptEngine
-						.eval("var mapFunction = function(inputHeaders, inputField, inputValue, outputField, line) { return "
-								+ this.mapping + "; };");
+						.eval("var mapFunction = function(inputHeaders, inputField, inputValue, outputField, line) { "
+								+ this.mapping + " };");
 			} catch (ScriptException e) {
 				throw new RuntimeException(e);
 			}
@@ -143,7 +143,7 @@ class CSVMapping {
 			try {
 				scriptEngine = SCRIPT_MANAGER.getEngineByName("lua");
 
-				compiledScript = ((Compilable) scriptEngine).compile("return " + this.mapping);
+				compiledScript = ((Compilable) scriptEngine).compile(this.mapping);
 			} catch (ScriptException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/com/github/ansell/csv/map/CSVMapping.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapping.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvmap;
+package com.github.ansell.csv.map;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/github/ansell/csv/sum/CSVSummariser.java
+++ b/src/main/java/com/github/ansell/csv/sum/CSVSummariser.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvsum;
+package com.github.ansell.csv.sum;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.github.ansell.csvutil.CSVUtil;
+import com.github.ansell.csv.util.CSVUtil;
 import com.github.ansell.jdefaultdict.JDefaultDict;
 
 import joptsimple.OptionException;

--- a/src/main/java/com/github/ansell/csv/util/CSVUtil.java
+++ b/src/main/java/com/github/ansell/csv/util/CSVUtil.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvutil;
+package com.github.ansell.csv.util;
 
 import java.io.IOException;
 import java.io.Reader;

--- a/src/main/java/com/github/ansell/csv/util/JSONUtil.java
+++ b/src/main/java/com/github/ansell/csv/util/JSONUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Peter Ansell
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * 
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.ansell.csv.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * JSON utilities used by CSV processors.
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public class JSONUtil {
+
+	private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+	private static final JsonFactory JSON_FACTORY = new JsonFactory(JSON_MAPPER);
+
+	public static void queryJSON(Reader input) throws JsonProcessingException, IOException {
+		JsonNode root = JSON_MAPPER.readTree(input);
+
+		JsonPointer ptr = JsonPointer.compile("");
+		root.at(ptr);
+	}
+
+	public static void toPrettyPrint(Reader input, Writer output) throws IOException {
+		final JsonGenerator jw = JSON_FACTORY.createGenerator(output);
+		jw.useDefaultPrettyPrinter();
+		JsonParser parser = JSON_FACTORY.createParser(input);
+		jw.writeObject(parser.readValueAsTree());
+	}
+
+}

--- a/src/test/java/com/github/ansell/csv/map/CSVMapperTest.java
+++ b/src/test/java/com/github/ansell/csv/map/CSVMapperTest.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvmap;
+package com.github.ansell.csv.map;
 
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
@@ -35,6 +35,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
+import com.github.ansell.csv.map.CSVMapper;
 
 import joptsimple.OptionException;
 
@@ -67,7 +69,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainNoArgs() throws Exception {
@@ -77,7 +79,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainHelp() throws Exception {
@@ -86,7 +88,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainFileDoesNotExist() throws Exception {
@@ -99,7 +101,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainMappingDoesNotExist() throws Exception {
@@ -112,7 +114,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainEmpty() throws Exception {
@@ -128,7 +130,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainComplete() throws Exception {
@@ -138,7 +140,7 @@ public class CSVMapperTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvmap.CSVMapper#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.map.CSVMapper#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainCompleteWithOutputFile() throws Exception {

--- a/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
+++ b/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
@@ -27,6 +27,8 @@ package com.github.ansell.csv.map;
 
 import static org.junit.Assert.*;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import javax.script.Bindings;
@@ -84,4 +86,11 @@ public class ScriptEngineTest {
 		assertEquals("testreturnvalue", result);
 	}
 
+	@Test
+	public final void testDate() throws Exception {
+		LocalDate parseDate1 = LocalDate.parse("21-Sep-14", DateTimeFormatter.ofPattern("d-MMM-yy"));
+		LocalDate parsedDate = LocalDate.parse("2-Apr-14", DateTimeFormatter.ofPattern("d-MMM-yy"));
+		System.out.println(parsedDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
+	}
+	
 }

--- a/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
+++ b/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvmap;
+package com.github.ansell.csv.map;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/github/ansell/csv/sum/CSVSummariserTest.java
+++ b/src/test/java/com/github/ansell/csv/sum/CSVSummariserTest.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvsum;
+package com.github.ansell.csv.sum;
 
 import static org.junit.Assert.*;
 
@@ -38,6 +38,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
+import com.github.ansell.csv.sum.CSVSummariser;
 
 import joptsimple.OptionException;
 
@@ -56,7 +58,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainNoArgs() throws Exception {
@@ -66,7 +68,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainHelp() throws Exception {
@@ -75,7 +77,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainFileDoesNotExist() throws Exception {
@@ -87,7 +89,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainEmpty() throws Exception {
@@ -102,7 +104,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderNoLines() throws Exception {
@@ -115,7 +117,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderOneLine() throws Exception {
@@ -128,7 +130,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderOneLineFileOutput() throws Exception {
@@ -145,7 +147,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderOneLineFileOutputFewSamples() throws Exception {
@@ -162,7 +164,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderOneLineEmptyValue() throws Exception {
@@ -177,7 +179,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderMultipleLinesWithEmptyValues() throws Exception {
@@ -192,7 +194,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testMainSingleHeaderTwentyOneLines() throws Exception {
@@ -207,7 +209,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testSummariseInteger() throws Exception {
@@ -217,7 +219,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testSummariseDouble() throws Exception {
@@ -227,7 +229,7 @@ public class CSVSummariserTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvsum.CSVSummariser#main(java.lang.String[])}.
+	 * {@link com.github.ansell.csv.sum.CSVSummariser#main(java.lang.String[])}.
 	 */
 	@Test
 	public final void testSummariseAllSampleValues() throws Exception {

--- a/src/test/java/com/github/ansell/csv/util/CSVUtilTest.java
+++ b/src/test/java/com/github/ansell/csv/util/CSVUtilTest.java
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.github.ansell.csvutil;
+package com.github.ansell.csv.util;
 
 import static org.junit.Assert.*;
 
@@ -36,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.github.ansell.csvutil.CSVUtil;
+import com.github.ansell.csv.util.CSVUtil;
 
 /**
  * Tests for {@link CSVUtil}.
@@ -50,7 +50,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -65,7 +65,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -80,7 +80,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -95,7 +95,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -110,7 +110,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -126,7 +126,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -145,7 +145,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -162,7 +162,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -182,7 +182,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test
@@ -202,7 +202,7 @@ public class CSVUtilTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csvutil.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVUtil#streamCSV(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
 	 * .
 	 */
 	@Test

--- a/src/test/java/com/github/ansell/csv/util/JSONUtilTest.java
+++ b/src/test/java/com/github/ansell/csv/util/JSONUtilTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, Peter Ansell
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * 
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.ansell.csv.util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonPointer;
+
+/**
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public class JSONUtilTest {
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.JSONUtil#toPrettyPrint(java.io.Reader, java.io.Writer)}
+	 * .
+	 */
+	@Test
+	public final void testToPrettyPrint() throws Exception {
+		StringWriter output = new StringWriter();
+		StringReader input = new StringReader("{\"test\":\"something\"}");
+		JSONUtil.toPrettyPrint(input, output);
+		System.out.println(output.toString());
+		assertTrue(output.toString().contains("\"test\" : \"something\""));
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.JSONUtil#queryJSON(java.io.Reader, JsonPointer)}
+	 * .
+	 */
+	@Test
+	public final void testQueryJSON() throws Exception {
+		StringReader input = new StringReader("{ \"test\": \"something\"}");
+		JsonPointer jpath = JsonPointer.compile("/test");
+		String result = JSONUtil.queryJSON(input, jpath);
+		System.out.println(result);
+		assertEquals("something", result);
+	}
+
+}

--- a/src/test/resources/com/github/ansell/csvmap/ala-test.json
+++ b/src/test/resources/com/github/ansell/csvmap/ala-test.json
@@ -1,0 +1,110 @@
+{
+  "searchResults" : {
+    "pageSize" : 10,
+    "startIndex" : 0,
+    "totalRecords" : 3,
+    "sort" : "score",
+    "dir" : "desc",
+    "status" : "OK",
+    "facetResults" : [ {
+      "fieldName" : "idxtype",
+      "fieldResult" : [ {
+        "label" : "TAXON",
+        "count" : 3,
+        "fieldValue" : "TAXON"
+      } ]
+    }, {
+      "fieldName" : "australian_s",
+      "fieldResult" : [ {
+        "label" : "recorded",
+        "count" : 3,
+        "fieldValue" : "recorded"
+      } ]
+    }, {
+      "fieldName" : "speciesGroup",
+      "fieldResult" : [ {
+        "label" : "Plants",
+        "count" : 1,
+        "fieldValue" : "Plants"
+      } ]
+    }, {
+      "fieldName" : "rank",
+      "fieldResult" : [ {
+        "label" : "species",
+        "count" : 3,
+        "fieldValue" : "species"
+      } ]
+    } ],
+    "query" : " (commonName:banksia AND commonName:occidentalis) OR  text:\"banksia occidentalis\" OR  (scientificNameText:banksia AND scientificNameText:occidentalis) OR  (name_complete:banksia AND name_complete:occidentalis) OR  concat_name:\"banksiaoccidentalis\" OR  (stopped_common_name:banksia AND stopped_common_name:occidentalis) OR  exact_text:\"banksia occidentalis\"^100000000000 OR  text:\"Banksia occidentalis\"",
+    "results" : [ {
+      "guid" : "urn:lsid:biodiversity.org.au:apni.taxon:293711",
+      "name" : "Banksia occidentalis",
+      "idxType" : "TAXON",
+      "score" : 14.466862,
+      "parentGuid" : "urn:lsid:biodiversity.org.au:apni.taxon:318387",
+      "commonName" : "Red Swamp Banksia, Water Bush Banksia, Waterbush",
+      "nameComplete" : "Banksia occidentalis",
+      "commonNameSingle" : "Red Swamp Banksia",
+      "hasChildren" : false,
+      "rank" : "species",
+      "rankId" : 7000,
+      "rawRank" : "Species",
+      "isAustralian" : "recorded",
+      "highlight" : "<strong>banksia occidentalis</strong>",
+      "image" : "/data/bie/1034/123/1235500/raw.jpg",
+      "thumbnail" : "/data/bie/1034/123/1235500/thumbnail.jpg",
+      "left" : 284409,
+      "right" : 284410,
+      "kingdom" : "Plantae",
+      "phylum" : "Charophyta",
+      "classs" : "Equisetopsida",
+      "order" : "Proteales",
+      "family" : "Proteaceae",
+      "genus" : "Banksia",
+      "author" : "R.Br.",
+      "linkIdentifier" : "Banksia+occidentalis",
+      "occCount" : 306,
+      "imageSource" : "dr413",
+      "imageCount" : 16,
+      "isExcluded" : false,
+      "imageUrl" : "http://bie.ala.org.au/repo/1034/123/1235500/raw.jpg",
+      "largeImageUrl" : "http://bie.ala.org.au/repo/1034/123/1235500/largeRaw.jpg",
+      "smallImageUrl" : "http://bie.ala.org.au/repo/1034/123/1235500/smallRaw.jpg",
+      "thumbnailUrl" : "http://bie.ala.org.au/repo/1034/123/1235500/thumbnail.jpg",
+      "imageMetadataUrl" : "http://bie.ala.org.au/repo/1034/123/1235500/dc"
+    }, {
+      "guid" : "urn:lsid:biodiversity.org.au:apni.taxon:293711",
+      "name" : "Banksia occidentalis R.Br. subsp. occidentalis  ",
+      "idxType" : "TAXON",
+      "score" : 1.1726418E-10,
+      "commonName" : "Red Swamp Banksia, Water Bush Banksia, Waterbush",
+      "acceptedConceptName" : "Banksia occidentalis",
+      "synonymRelationship" : "includes",
+      "synonymDescription" : "nomenclatural",
+      "hasChildren" : false,
+      "rank" : "species",
+      "rankId" : 7000,
+      "rawRank" : "Species",
+      "isAustralian" : "recorded",
+      "highlight" : "<strong>banksia occidentalis</strong>",
+      "occCount" : 306
+    }, {
+      "guid" : "urn:lsid:biodiversity.org.au:apni.taxon:293711",
+      "name" : "Banksia occidentalis subsp. formosa Hopper  ",
+      "idxType" : "TAXON",
+      "score" : 1.0981921E-10,
+      "commonName" : "Red Swamp Banksia, Water Bush Banksia, Waterbush",
+      "acceptedConceptName" : "Banksia occidentalis",
+      "synonymRelationship" : "includes",
+      "synonymDescription" : "taxonomic",
+      "hasChildren" : false,
+      "rank" : "species",
+      "rankId" : 7000,
+      "rawRank" : "Species",
+      "isAustralian" : "recorded",
+      "highlight" : "<strong>banksia occidentalis</strong>",
+      "author" : "Hopper",
+      "occCount" : 306
+    } ]
+  }
+}

--- a/src/test/resources/com/github/ansell/csvmap/test-mapping.csv
+++ b/src/test/resources/com/github/ansell/csvmap/test-mapping.csv
@@ -1,9 +1,9 @@
 OldField,NewField,Language,Mapping
 Field1,anotherfield,,
 Field2,Field2,,
-Field2,varietyOrSubspecies,Javascript,"inputValue.equalsIgnoreCase(""var."") ? ""varietas"" : inputValue.equalsIgnoreCase(""subsp."") ? ""subspecies"" : """""
+Field2,varietyOrSubspecies,Javascript,"return inputValue.equalsIgnoreCase(""var."") ? ""varietas"" : inputValue.equalsIgnoreCase(""subsp."") ? ""subspecies"" : """";"
 Field3,Field3,,
 Field3,naturalised,Groovy,"inputValue.equalsIgnoreCase(""Y"") ? ""naturalised"" : """" "
 Field4,Field4,,
-Field4,unrelatedField,Javascript,"(!line.get(inputHeaders.indexOf(""Field3"")).trim().isEmpty() && !line.get(inputHeaders.indexOf(""Field4"")).trim().isEmpty() ? ""Useful"" : """")"
-Field5,Field5,Lua,"inputValue .. ""a"""
+Field4,unrelatedField,Javascript,"return (!line.get(inputHeaders.indexOf(""Field3"")).trim().isEmpty() && !line.get(inputHeaders.indexOf(""Field4"")).trim().isEmpty() ? ""Useful"" : """");"
+Field5,Field5,Lua,"return inputValue .. ""a"""


### PR DESCRIPTION
Now requires the return keyword for javascript, but it enables arbitrary functions with multiple return points to be used for complex cases.