### PR TITLE
Inline row submission

### DIFF
--- a/src/main/java/com/github/ansell/csv/access/AccessMapper.java
+++ b/src/main/java/com/github/ansell/csv/access/AccessMapper.java
@@ -439,7 +439,8 @@ public class AccessMapper {
 
 		try {
 			return ValueMapping.mapLine(inputHeaders, nextEmittedRow, Collections.emptyList(), Collections.emptyList(),
-					map, primaryKeys, -1, -1);
+					map, primaryKeys, -1, -1, l -> {
+					});
 		} catch (final LineFilteredException e) {
 			// Swallow line filtered exception and return null below to
 			// eliminate it

--- a/src/main/java/com/github/ansell/csv/access/AccessMapper.java
+++ b/src/main/java/com/github/ansell/csv/access/AccessMapper.java
@@ -288,7 +288,7 @@ public class AccessMapper {
 								joinersForThread);
 						final Consumer<Map<String, Object>> originRowConsumer = Unchecked.consumer(r -> {
 							List<String> mappedRow = mapNextRow(map, foreignKeyMappingForThread, joinersForThread,
-									nextOriginTable, r, db, primaryKeys);
+									nextOriginTable, r, db, primaryKeys, l -> writerQueue.add(l));
 							if (mappedRow != null) {
 								writerQueue.add(mappedRow);
 							}
@@ -377,7 +377,8 @@ public class AccessMapper {
 	private static List<String> mapNextRow(List<ValueMapping> map,
 			ConcurrentMap<String, ConcurrentMap<ValueMapping, Tuple2<String, String>>> foreignKeyMapping,
 			ConcurrentMap<ValueMapping, Joiner> joiners, String originTable, Map<String, Object> nextRow,
-			Database database, JDefaultDict<String, Set<String>> primaryKeys) throws IOException {
+			Database database, JDefaultDict<String, Set<String>> primaryKeys, Consumer<List<String>> mapLineConsumer)
+					throws IOException {
 		// Rows, indexed by the table that they came from
 		ConcurrentMap<String, Map<String, Object>> componentRowsForThisRow = new ConcurrentHashMap<>();
 		componentRowsForThisRow.put(originTable, nextRow);
@@ -439,8 +440,7 @@ public class AccessMapper {
 
 		try {
 			return ValueMapping.mapLine(inputHeaders, nextEmittedRow, Collections.emptyList(), Collections.emptyList(),
-					map, primaryKeys, -1, -1, l -> {
-					});
+					map, primaryKeys, -1, -1, mapLineConsumer);
 		} catch (final LineFilteredException e) {
 			// Swallow line filtered exception and return null below to
 			// eliminate it

--- a/src/main/java/com/github/ansell/csv/map/CSVMapper.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapper.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -140,8 +141,14 @@ public final class CSVMapper {
 			JDefaultDict<String, Set<String>> primaryKeys = new JDefaultDict<>(k -> new HashSet<>());
 			AtomicInteger lineNumber = new AtomicInteger(0);
 			AtomicInteger filteredLineNumber = new AtomicInteger(0);
+			Consumer<List<String>> mapLineConsumer = Unchecked.consumer(l -> {
+				previousLine.clear();
+				previousLine.addAll(l);
+				previousMappedLine.clear();
+				previousMappedLine.addAll(l);
+				csvWriter.write(l);
+			});
 			CSVUtil.streamCSV(input, h -> inputHeaders.addAll(h), (h, l) -> {
-				List<String> mapLine = null;
 				int nextLineNumber = lineNumber.incrementAndGet();
 				int nextFilteredLineNumber = filteredLineNumber.incrementAndGet();
 				try {
@@ -159,14 +166,7 @@ public final class CSVMapper {
 					}
 				}
 				return null;
-			} , Unchecked.consumer(l -> {
-				previousLine.clear();
-				previousLine.addAll(l);
-				previousMappedLine.clear();
-				previousMappedLine.addAll(l);
-				csvWriter.write(l);
-			}));
-
+			} , mapLineConsumer);
 		}
 	}
 

--- a/src/main/java/com/github/ansell/csv/map/CSVMapper.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapper.java
@@ -145,25 +145,27 @@ public final class CSVMapper {
 				int nextLineNumber = lineNumber.incrementAndGet();
 				int nextFilteredLineNumber = filteredLineNumber.incrementAndGet();
 				try {
-					mapLine = ValueMapping.mapLine(inputHeaders, l, previousLine, previousMappedLine, map, primaryKeys, nextLineNumber, nextFilteredLineNumber);
-					previousLine.clear();
-					previousLine.addAll(l);
-					previousMappedLine.clear();
-					if (mapLine != null) {
-						previousMappedLine.addAll(mapLine);
-					}
-					return mapLine;
+					return ValueMapping.mapLine(inputHeaders, l, previousLine, previousMappedLine, map, primaryKeys,
+							nextLineNumber, nextFilteredLineNumber);
 				} catch (final LineFilteredException e) {
 					// Swallow line filtered exception and return null below to
 					// eliminate it
-					// We expect streamCSV to operate in sequential order, print a warning if it doesn't
-					boolean success = filteredLineNumber.compareAndSet(nextFilteredLineNumber, nextFilteredLineNumber -1);
-					if(!success) {
+					// We expect streamCSV to operate in sequential order, print
+					// a warning if it doesn't
+					boolean success = filteredLineNumber.compareAndSet(nextFilteredLineNumber,
+							nextFilteredLineNumber - 1);
+					if (!success) {
 						System.out.println("Line numbers may not be consistent");
 					}
 				}
 				return null;
-			} , Unchecked.consumer(l -> csvWriter.write(l)));
+			} , Unchecked.consumer(l -> {
+				previousLine.clear();
+				previousLine.addAll(l);
+				previousMappedLine.clear();
+				previousMappedLine.addAll(l);
+				csvWriter.write(l);
+			}));
 
 		}
 	}

--- a/src/main/java/com/github/ansell/csv/map/CSVMapper.java
+++ b/src/main/java/com/github/ansell/csv/map/CSVMapper.java
@@ -153,7 +153,7 @@ public final class CSVMapper {
 				int nextFilteredLineNumber = filteredLineNumber.incrementAndGet();
 				try {
 					return ValueMapping.mapLine(inputHeaders, l, previousLine, previousMappedLine, map, primaryKeys,
-							nextLineNumber, nextFilteredLineNumber);
+							nextLineNumber, nextFilteredLineNumber, mapLineConsumer);
 				} catch (final LineFilteredException e) {
 					// Swallow line filtered exception and return null below to
 					// eliminate it

--- a/src/main/java/com/github/ansell/csv/util/CSVUtil.java
+++ b/src/main/java/com/github/ansell/csv/util/CSVUtil.java
@@ -389,7 +389,7 @@ public final class CSVUtil {
 					}
 
 					return ValueMapping.mapLine(mergedInputHeaders, nextMergedLine, previousLine, previousMappedLine,
-							map, primaryKeys, nextLineNumber, nextFilteredLineNumber);
+							map, primaryKeys, nextLineNumber, nextFilteredLineNumber, mapLineConsumer);
 				} catch (final LineFilteredException e) {
 					// Swallow line filtered exception and return null below to
 					// eliminate it
@@ -406,7 +406,6 @@ public final class CSVUtil {
 
 			if (!leftOuterJoin) {
 				otherLines.stream().filter(l -> !matchedOtherLines.contains(l)).forEach(Unchecked.consumer(l -> {
-					List<String> mapLine = null;
 					int nextLineNumber = lineNumber.incrementAndGet();
 					int nextFilteredLineNumber = filteredLineNumber.incrementAndGet();
 					try {
@@ -420,15 +419,9 @@ public final class CSVUtil {
 							}
 						}
 
-						mapLine = ValueMapping.mapLine(otherH, nextMergedLine, previousLine, previousMappedLine, map,
-								primaryKeys, nextLineNumber, nextFilteredLineNumber);
-						previousLine.clear();
-						previousLine.addAll(l);
-						previousMappedLine.clear();
-						if (mapLine != null) {
-							previousMappedLine.addAll(mapLine);
-						}
-						csvWriter.write(mapLine);
+						mapLineConsumer
+								.accept(ValueMapping.mapLine(otherH, nextMergedLine, previousLine, previousMappedLine,
+										map, primaryKeys, nextLineNumber, nextFilteredLineNumber, mapLineConsumer));
 					} catch (final LineFilteredException e) {
 						// Swallow line filtered exception and return null below
 						// to

--- a/src/main/java/com/github/ansell/csv/util/ValueMapping.java
+++ b/src/main/java/com/github/ansell/csv/util/ValueMapping.java
@@ -368,6 +368,7 @@ public class ValueMapping {
 				javascriptFunction.append("var String = Java.type('java.lang.String'); \n");
 				javascriptFunction.append("var MessageDigest = Java.type('java.security.MessageDigest'); \n");
 				javascriptFunction.append("var BigInteger = Java.type('java.math.BigInteger'); \n");
+				javascriptFunction.append("var Arrays = Java.type('java.util.Arrays'); \n");
 				javascriptFunction.append("var digest = function(value, algorithm, formatPattern) { if(!algorithm) { algorithm = \"SHA-256\"; } if(!formatPattern) { formatPattern = \"%064x\";} var md = MessageDigest.getInstance(algorithm); md.update(value.getBytes(\"UTF-8\")); var digestValue = md.digest(); return String.format(formatPattern, new BigInteger(1, digestValue));}; \n");
 				javascriptFunction.append(
 						"var dateMatches = function(dateValue, format) { try {\n format.parse(dateValue); \n return true; \n } catch(e) { } \n return false; }; \n");

--- a/src/main/java/com/github/ansell/csv/util/ValueMapping.java
+++ b/src/main/java/com/github/ansell/csv/util/ValueMapping.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.script.Bindings;
@@ -118,7 +119,7 @@ public class ValueMapping {
 
 	public static List<String> mapLine(List<String> inputHeaders, List<String> line, List<String> previousLine,
 			List<String> previousMappedLine, List<ValueMapping> map, JDefaultDict<String, Set<String>> primaryKeys, int lineNumber,
-			int filteredLineNumber) throws LineFilteredException {
+			int filteredLineNumber, Consumer<List<String>> mapLineConsumer) throws LineFilteredException {
 
 		HashMap<String, String> outputValues = new HashMap<>(map.size(), 0.75f);
 
@@ -126,7 +127,7 @@ public class ValueMapping {
 				.collect(Collectors.toList());
 		map.forEach(nextMapping -> {
 			String mappedValue = nextMapping.apply(inputHeaders, line, previousLine, previousMappedLine, outputHeaders,
-					outputValues, primaryKeys, lineNumber, filteredLineNumber);
+					outputValues, primaryKeys, lineNumber, filteredLineNumber, mapLineConsumer);
 			outputValues.put(nextMapping.getOutputField(), mappedValue);
 		});
 
@@ -195,7 +196,7 @@ public class ValueMapping {
 
 	private String apply(List<String> inputHeaders, List<String> line, List<String> previousLine,
 			List<String> previousMappedLine, List<String> outputHeaders, Map<String, String> mappedLine,
-			JDefaultDict<String, Set<String>> primaryKeys, int lineNumber, int filteredLineNumber) {
+			JDefaultDict<String, Set<String>> primaryKeys, int lineNumber, int filteredLineNumber, Consumer<List<String>> mapLineConsumer) {
 		int indexOf = inputHeaders.indexOf(getInputField());
 		String nextInputValue;
 		if (indexOf >= 0) {
@@ -221,7 +222,7 @@ public class ValueMapping {
 					// from the mapping
 					return (String) ((Invocable) scriptEngine).invokeFunction("mapFunction", inputHeaders,
 							this.getInputField(), nextInputValue, outputHeaders, this.getOutputField(), line,
-							mappedLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber);
+							mappedLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber, mapLineConsumer);
 				} else if (compiledScript != null) {
 					Bindings bindings = scriptEngine.createBindings();
 					// inputHeaders, inputField, inputValue, outputField, line
@@ -237,6 +238,7 @@ public class ValueMapping {
 					bindings.put("primaryKeys", primaryKeys);
 					bindings.put("lineNumber", lineNumber);
 					bindings.put("filteredLineNumber", filteredLineNumber);
+					bindings.put("mapLineConsumer", mapLineConsumer);
 					return (String) compiledScript.eval(bindings);
 				} else {
 					throw new UnsupportedOperationException(
@@ -377,7 +379,7 @@ public class ValueMapping {
 				javascriptFunction.append(
 						"var columnFunctionMap = function(searchHeader, mapLine) { return mapLine.get(searchHeader); };\n");
 				javascriptFunction.append(
-						"var mapFunction = function(inputHeaders, inputField, inputValue, outputHeaders, outputField, line, mapLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber) { ");
+						"var mapFunction = function(inputHeaders, inputField, inputValue, outputHeaders, outputField, line, mapLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber, mapLineConsumer) { ");
 				javascriptFunction.append(
 						"    var primaryKeyFilter = function(nextPrimaryKey, primaryKeyField) { \n if(!primaryKeyField) { primaryKeyField = \"Primary\"; } \n return !primaryKeys.get(primaryKeyField).add(nextPrimaryKey) ? filter() : nextPrimaryKey; }; \n ");
 				javascriptFunction.append(
@@ -396,7 +398,7 @@ public class ValueMapping {
 				scriptEngine = SCRIPT_MANAGER.getEngineByName("groovy");
 
 				scriptEngine
-						.eval("def mapFunction(inputHeaders, inputField, inputValue, outputHeaders, outputField, line, mapLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber) {  "
+						.eval("def mapFunction(inputHeaders, inputField, inputValue, outputHeaders, outputField, line, mapLine, previousLine, previousMappedLine, primaryKeys, lineNumber, filteredLineNumber, mapLineConsumer) {  "
 								+ this.mapping + " }");
 			} catch (ScriptException e) {
 				throw new RuntimeException(e);

--- a/src/test/java/com/github/ansell/csv/util/ValueMappingTest.java
+++ b/src/test/java/com/github/ansell/csv/util/ValueMappingTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +40,10 @@ public class ValueMappingTest {
 	private ValueMapping testDateMatching;
 	private ValueMapping testDateMapping;
 	private JDefaultDict<String, Set<String>> testPrimaryKeys;
+
+	private static final Consumer<List<String>> UNEXPECTED_LINE_CONSUMER = l -> {
+		fail("Not expecting mapLineConsumer to be called in this test.");
+	};
 
 	@Before
 	public void setUp() throws Exception {
@@ -123,12 +128,11 @@ public class ValueMappingTest {
 
 	@Test
 	public final void testMapLine() {
-		List<String> mapLine = ValueMapping
-				.mapLine(Arrays.asList("anInput", "anInput3", "aDifferentInput", "anInput4"),
-						Arrays.asList("testValue1", "testValue2", "xyzabc", "defghi"), Collections.emptyList(),
-						Collections.emptyList(), Arrays.asList(testDefaultMapping, testDefaultMapping3,
-								testDefaultMapping4, testJavascriptMapping, testPreviousMapping),
-						testPrimaryKeys, 1, 1);
+		List<String> mapLine = ValueMapping.mapLine(Arrays.asList("anInput", "anInput3", "aDifferentInput", "anInput4"),
+				Arrays.asList("testValue1", "testValue2", "xyzabc", "defghi"),
+				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDefaultMapping, testDefaultMapping3,
+						testDefaultMapping4, testJavascriptMapping, testPreviousMapping),
+				testPrimaryKeys, 1, 1, UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(4, mapLine.size());
 		assertEquals("testValue1", mapLine.get(0));
@@ -144,7 +148,7 @@ public class ValueMappingTest {
 				Arrays.asList("testValue1", "testValue2", "xyzabc", "defghi"),
 				Arrays.asList("testValue1", "testValue2", "x", "no-previous"), Arrays.asList(testDefaultMapping,
 						testDefaultMapping3, testDefaultMapping4, testJavascriptMapping, testPreviousMapping),
-				testPrimaryKeys, 1, 1);
+				testPrimaryKeys, 1, 1, UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(4, mapLine.size());
 		assertEquals("testValue1A", mapLine.get(0));
@@ -157,7 +161,8 @@ public class ValueMappingTest {
 	public final void testMapLinePrimaryKey() {
 		List<String> mapLine1 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey1", "testValue1"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine1.size());
 		assertEquals("testKey1", mapLine1.get(0));
@@ -165,7 +170,8 @@ public class ValueMappingTest {
 
 		List<String> mapLine2 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey2", "testValue2"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine2.size());
 		assertEquals("testKey2", mapLine2.get(0));
@@ -175,14 +181,16 @@ public class ValueMappingTest {
 		thrown.expect(LineFilteredException.class);
 		ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"), Arrays.asList("testKey2", "testValue3"),
 				Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMapping, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 	}
 
 	@Test
 	public final void testMapLinePrimaryKeyFunction() {
 		List<String> mapLine1 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey1", "testValue1"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine1.size());
 		assertEquals("testKey1", mapLine1.get(0));
@@ -190,7 +198,8 @@ public class ValueMappingTest {
 
 		List<String> mapLine2 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey2", "testValue2"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine2.size());
 		assertEquals("testKey2", mapLine2.get(0));
@@ -200,14 +209,16 @@ public class ValueMappingTest {
 		thrown.expect(LineFilteredException.class);
 		ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"), Arrays.asList("testKey2", "testValue3"),
 				Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1);
+				Arrays.asList(testJavascriptPrimaryKeyMappingFunction, testDefaultMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 	}
 
 	@Test
 	public final void testMapLineLineNumber() {
 		List<String> mapLine1 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey1", "testValue1"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptLineNumber, testDefaultMapping), testPrimaryKeys, 123, 101);
+				Arrays.asList(testJavascriptLineNumber, testDefaultMapping), testPrimaryKeys, 123, 101,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine1.size());
 		assertEquals("123", mapLine1.get(0));
@@ -215,7 +226,8 @@ public class ValueMappingTest {
 
 		List<String> mapLine2 = ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"),
 				Arrays.asList("testKey2", "testValue2"), Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptFilteredLineNumber, testDefaultMapping), testPrimaryKeys, 123, 101);
+				Arrays.asList(testJavascriptFilteredLineNumber, testDefaultMapping), testPrimaryKeys, 123, 101,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(2, mapLine2.size());
 		assertEquals("101", mapLine2.get(0));
@@ -225,14 +237,15 @@ public class ValueMappingTest {
 		thrown.expect(LineFilteredException.class);
 		ValueMapping.mapLine(Arrays.asList("aDifferentInput", "anInput"), Arrays.asList("testKey2", "testValue3"),
 				Collections.emptyList(), Collections.emptyList(),
-				Arrays.asList(testJavascriptFilteredLineNumber, testDefaultMapping), testPrimaryKeys, 124, 101);
+				Arrays.asList(testJavascriptFilteredLineNumber, testDefaultMapping), testPrimaryKeys, 124, 101,
+				UNEXPECTED_LINE_CONSUMER);
 	}
 
 	@Test
 	public final void testMapLineDateMatchInvalid() {
 		List<String> mapLine = ValueMapping.mapLine(Arrays.asList("dateInput"), Arrays.asList("testNotADate"),
 				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMatching), testPrimaryKeys, 1,
-				1);
+				1, UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(1, mapLine.size());
 		assertEquals("fix-your-date-format", mapLine.get(0));
@@ -242,7 +255,7 @@ public class ValueMappingTest {
 	public final void testMapLineDateMatchValid() {
 		List<String> mapLine = ValueMapping.mapLine(Arrays.asList("dateInput"), Arrays.asList("2013-01-30"),
 				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMatching), testPrimaryKeys, 1,
-				1);
+				1, UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(1, mapLine.size());
 		assertEquals("2013-01-30", mapLine.get(0));
@@ -251,8 +264,8 @@ public class ValueMappingTest {
 	@Test
 	public final void testMapLineDateMatchInvalidConvert() {
 		List<String> mapLine = ValueMapping.mapLine(Arrays.asList("dateInput"), Arrays.asList("testNotADate"),
-				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMapping), testPrimaryKeys, 1,
-				1);
+				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(1, mapLine.size());
 		assertEquals("fix-your-date-format", mapLine.get(0));
@@ -261,8 +274,8 @@ public class ValueMappingTest {
 	@Test
 	public final void testMapLineDateMatchValidConvert() {
 		List<String> mapLine = ValueMapping.mapLine(Arrays.asList("dateInput"), Arrays.asList("2013-01-30"),
-				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMapping), testPrimaryKeys, 1,
-				1);
+				Collections.emptyList(), Collections.emptyList(), Arrays.asList(testDateMapping), testPrimaryKeys, 1, 1,
+				UNEXPECTED_LINE_CONSUMER);
 
 		assertEquals(1, mapLine.size());
 		assertEquals("2013-W05-3", mapLine.get(0));

--- a/src/test/resources/com/github/ansell/csvmap/test-mapping-previous.csv
+++ b/src/test/resources/com/github/ansell/csvmap/test-mapping-previous.csv
@@ -1,0 +1,3 @@
+OldField,NewField,Shown,Language,Mapping
+Field1,anotherfield,,,
+Field2,PreviousField1,,Javascript,"return previousLine.isEmpty() ? ""no-previous"" : previousLine.get(outputHeaders.indexOf(""anotherfield""));"


### PR DESCRIPTION
Allow inline row submission to allow a single input row to map to multiple output rows as is necessary for some datasets that attach multiple observations to single rows