### PR TITLE
Fix #21 : Allow overriding of escape, quote and column characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,15 @@ Run csvmap with a sample csv file:
 
 # Changelog
 
+## 2017-06-07
+* Add support for specifying quote/line ending/field separator characters in the CSVSummariser Java API. No support yet in the CLI
+
 ## 2017-04-03
-# Release 0.4.1
+* Release 0.4.1
 
 ## 2017-03-31
-# Add progress output for csvsum/csvmap/csvjoin
-# Add JSON utility functions to allow programmatic iteration of JSON files
+* Add progress output for csvsum/csvmap/csvjoin
+* Add JSON utility functions to allow programmatic iteration of JSON files
 
 ## 2017-03-30
 * Add support for header substitution for files with no header line

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<jackson.version>2.8.7</jackson.version>
+		<jackson.version>2.8.8</jackson.version>
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
@@ -215,7 +215,7 @@
 			<dependency>
 				<groupId>com.github.ansell.csv</groupId>
 				<artifactId>csvstream</artifactId>
-				<version>0.0.2</version>
+				<version>0.0.3-SNAPSHOT</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -277,7 +277,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.5.1</version>
+					<version>3.6.1</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
@@ -296,7 +296,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.0.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -347,12 +347,12 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.7.7.201606060606</version>
+					<version>0.7.9</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.20</version>
 					<configuration>
 						<!-- Travis build workaround, see https://github.com/travis-ci/travis-ci/issues/3396 -->
 						<argLine>${argLine} -Xmx1024m</argLine>
@@ -361,13 +361,13 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>appassembler-maven-plugin</artifactId>
-					<version>1.10</version>
+					<version>2.0.0</version>
 				</plugin>
 				<!-- Create code coverage reports and submit them to coveralls.io. -->
 				<plugin>
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>4.2.0</version>
+					<version>4.3.0</version>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 
 					only. It has no influence on the Maven build itself. -->

--- a/src/main/java/com/github/ansell/csv/sum/CSVSummariser.java
+++ b/src/main/java/com/github/ansell/csv/sum/CSVSummariser.java
@@ -240,6 +240,11 @@ public final class CSVSummariser {
 	 * 
 	 * @param input
 	 *            The input CSV file, as a {@link Reader}.
+	 * @param inputMapper
+	 *            The CsvMapper to use to parse the file into memory
+	 * @param inputSchema
+	 *            The CsvSchema to use to help the mapper parse the file into
+	 *            memory
 	 * @param output
 	 *            The output CSV file as a {@link Writer}.
 	 * @param mappingOutput
@@ -410,6 +415,11 @@ public final class CSVSummariser {
 	 * 
 	 * @param input
 	 *            The {@link Reader} containing the inputs to be summarised.
+	 * @param inputMapper
+	 *            The CsvMapper to use to parse the file into memory
+	 * @param inputSchema
+	 *            The CsvSchema to use to help the mapper parse the file into
+	 *            memory
 	 * @param emptyCounts
 	 *            A {@link JDefaultDict} to be populated with empty counts for
 	 *            each field
@@ -480,7 +490,7 @@ public final class CSVSummariser {
 			// We are a streaming summariser, and do not store the raw original
 			// lines. Only unique, non-empty, values are stored in the
 			// valueCounts map for uniqueness summaries
-		}, overrideHeaders, headerLineCount);
+		}, overrideHeaders, headerLineCount, inputMapper, inputSchema);
 		return headers;
 	}
 

--- a/src/main/java/com/github/ansell/csv/util/ValueMapping.java
+++ b/src/main/java/com/github/ansell/csv/util/ValueMapping.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 

--- a/src/test/java/com/github/ansell/csv/db/CSVUploadTest.java
+++ b/src/test/java/com/github/ansell/csv/db/CSVUploadTest.java
@@ -10,7 +10,6 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -18,17 +17,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
-
-import com.github.ansell.csv.sum.CSVSummariser;
 
 import joptsimple.OptionException;
 

--- a/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
+++ b/src/test/java/com/github/ansell/csv/map/ScriptEngineTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import javax.script.Bindings;
 import javax.script.Compilable;
@@ -88,8 +89,8 @@ public class ScriptEngineTest {
 
 	@Test
 	public final void testDate() throws Exception {
-		LocalDate parseDate1 = LocalDate.parse("21-Sep-14", DateTimeFormatter.ofPattern("d-MMM-yy"));
-		LocalDate parsedDate = LocalDate.parse("2-Apr-14", DateTimeFormatter.ofPattern("d-MMM-yy"));
+		LocalDate parseDate1 = LocalDate.parse("21-Sep-14", DateTimeFormatter.ofPattern("d-MMM-yy").withLocale(Locale.US));
+		LocalDate parsedDate = LocalDate.parse("2-Apr-14", DateTimeFormatter.ofPattern("d-MMM-yy").withLocale(Locale.US));
 		System.out.println(parsedDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
 	}
 	

--- a/src/test/java/com/github/ansell/csv/util/ValueMappingTest.java
+++ b/src/test/java/com/github/ansell/csv/util/ValueMappingTest.java
@@ -383,7 +383,7 @@ public class ValueMappingTest {
 
 		LocalDate.parse("17/2/2016", dateFormatter);
 
-		DateTimeFormatter dateFormatter2 = DateTimeFormatter.ofPattern("d[d] MMM yyyy");
+		DateTimeFormatter dateFormatter2 = DateTimeFormatter.ofPattern("d[d] MMM yyyy").withLocale(Locale.US);
 
 		// The following never seems to work with a four digit year, with and
 		// without brackets for optionals


### PR DESCRIPTION
By default, parsing is done with the RFC4180 Section 2 CSV profile. These changes allow users to change the escape, quote, and column characters to match their requirements.

In particular, this is necessary to directly pass settings from DWC archive metadata.xml files through to here. See ansell/dwca-utils#4 and https://github.com/ansell/csvstream/issues/3